### PR TITLE
[RunWhen] - GitOps Manifest Updates for PersistentVolumeClaim-mongodata-users-mongo

### DIFF
--- a/kubernetes-manifests/cart-redis-total.yaml
+++ b/kubernetes-manifests/cart-redis-total.yaml
@@ -24,13 +24,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: acmefit  # has to match .spec.template.metadata.labels
+      app: acmefit # has to match .spec.template.metadata.labels
       service: cart-redis
   replicas: 1
   template:
     metadata:
       labels:
-        app: acmefit  # has to match .spec.selector.matchLabels
+        app: acmefit # has to match .spec.selector.matchLabels
         service: cart-redis
     spec:
       containers:
@@ -46,18 +46,18 @@ spec:
               containerPort: 6379
               protocol: "TCP"
           env:
-          - name: REDIS_HOST
-            value: 'cart-redis'
-          - name: REDIS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: cart-redis-pass
-                key: password
+            - name: REDIS_HOST
+              value: 'cart-redis'
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cart-redis-pass
+                  key: password
           volumeMounts:
             - mountPath: /var/lib/redis
               name: cart-redis-data
-#            - mountPath: /etc/redis
-#              name: redis-config
+              #            - mountPath: /etc/redis
+              #              name: redis-config
       volumes:
         - name: cart-redis-data
           emptyDir: {}

--- a/kubernetes-manifests/cart-total.yaml
+++ b/kubernetes-manifests/cart-total.yaml
@@ -36,44 +36,44 @@ spec:
         service: cart
     spec:
       volumes:
-      - name: acmefit-cart-data
-        emptyDir: {}
+        - name: acmefit-cart-data
+          emptyDir: {}
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-cart:latest
-        imagePullPolicy: "Always"
-        name: cart
-        env:
-        - name: REDIS_HOST
-          value: 'cart-redis'
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: cart-redis-pass
-              key: password
-        - name: REDIS_PORT
-          value: '6379'
-        - name: CART_PORT
-          value: '5000'
-        - name: USER_HOST
-          value: 'users'
-        - name: USER_PORT
-          value: '8083'
-        - name: JAEGER_AGENT_HOST
-          value: 'localhost'
-        - name: JAEGER_AGENT_PORT
-          value: '6831'
-        - name: AUTH_MODE
-          value: '1'
-        ports:
-        - containerPort: 5000
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-cart:latest
+          imagePullPolicy: "Always"
           name: cart
-        volumeMounts:
-        - mountPath: "/data"
-          name: "acmefit-cart-data"
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "500m"
+          env:
+            - name: REDIS_HOST
+              value: 'cart-redis'
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: cart-redis-pass
+                  key: password
+            - name: REDIS_PORT
+              value: '6379'
+            - name: CART_PORT
+              value: '5000'
+            - name: USER_HOST
+              value: 'users'
+            - name: USER_PORT
+              value: '8083'
+            - name: JAEGER_AGENT_HOST
+              value: 'localhost'
+            - name: JAEGER_AGENT_PORT
+              value: '6831'
+            - name: AUTH_MODE
+              value: '1'
+          ports:
+            - containerPort: 5000
+              name: cart
+          volumeMounts:
+            - mountPath: "/data"
+              name: "acmefit-cart-data"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/kubernetes-manifests/catalog-db-total.yaml
+++ b/kubernetes-manifests/catalog-db-total.yaml
@@ -24,34 +24,33 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: acmefit  # has to match .spec.template.metadata.labels
+      app: acmefit # has to match .spec.template.metadata.labels
       service: catalog-db
   replicas: 1
   template:
     metadata:
       labels:
-        app: acmefit  # has to match .spec.selector.matchLabels
+        app: acmefit # has to match .spec.selector.matchLabels
         service: catalog-db
     spec:
       containers:
         - name: catalog-mongo
           image: mongo:4
-          resources:
-            {}
+          resources: {}
           ports:
             - name: catalog-mongo
               containerPort: 27017
               protocol: "TCP"
           env:
-          - name: MONGO_INITDB_ROOT_USERNAME
-            value: 'mongoadmin'
-          - name: MONGO_INITDB_DATABASE
-            value: 'acmefit'
-          - name: MONGO_INITDB_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: catalog-mongo-pass
-                key: password
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: 'mongoadmin'
+            - name: MONGO_INITDB_DATABASE
+              value: 'acmefit'
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: catalog-mongo-pass
+                  key: password
           volumeMounts:
             - mountPath: /data/db
               name: mongodata

--- a/kubernetes-manifests/catalog-total.yaml
+++ b/kubernetes-manifests/catalog-total.yaml
@@ -36,46 +36,46 @@ spec:
         service: catalog
     spec:
       volumes:
-      - name: acmefit-catalog-data
-        emptyDir: {}
+        - name: acmefit-catalog-data
+          emptyDir: {}
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-catalog:latest
-        imagePullPolicy: "Always"
-        name: catalog
-        env:
-        - name: CATALOG_DB_HOST
-          value: 'catalog-mongo'
-        - name: CATALOG_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: catalog-mongo-pass
-              key: password
-        - name: CATALOG_DB_PORT
-          value: '27017'
-        - name: CATALOG_DB_USERNAME
-          value: 'mongoadmin'
-        - name: CATALOG_PORT
-          value: '8082'
-        - name: CATALOG_VERSION
-          value: 'v1'
-        - name: USERS_HOST
-          value: 'users'
-        - name: USERS_PORT
-          value: '8083'
-        - name: JAEGER_AGENT_HOST
-          value: 'localhost'
-        - name: JAEGER_AGENT_PORT
-          value: '6831'
-        ports:
-        - containerPort: 8082
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-catalog:latest
+          imagePullPolicy: "Always"
           name: catalog
-        volumeMounts:
-        - mountPath: "/data"
-          name: "acmefit-catalog-data"
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "500m"
+          env:
+            - name: CATALOG_DB_HOST
+              value: 'catalog-mongo'
+            - name: CATALOG_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: catalog-mongo-pass
+                  key: password
+            - name: CATALOG_DB_PORT
+              value: '27017'
+            - name: CATALOG_DB_USERNAME
+              value: 'mongoadmin'
+            - name: CATALOG_PORT
+              value: '8082'
+            - name: CATALOG_VERSION
+              value: 'v1'
+            - name: USERS_HOST
+              value: 'users'
+            - name: USERS_PORT
+              value: '8083'
+            - name: JAEGER_AGENT_HOST
+              value: 'localhost'
+            - name: JAEGER_AGENT_PORT
+              value: '6831'
+          ports:
+            - containerPort: 8082
+              name: catalog
+          volumeMounts:
+            - mountPath: "/data"
+              name: "acmefit-catalog-data"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/kubernetes-manifests/frontend-total.yaml
+++ b/kubernetes-manifests/frontend-total.yaml
@@ -38,31 +38,31 @@ spec:
         service: frontend
     spec:
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-front-end:latest
-        name: frontend
-        env:
-        - name: FRONTEND_PORT
-          value: '3000'
-        - name: USERS_HOST
-          value: 'users'
-        - name: CATALOG_HOST
-          value: 'catalog'
-        - name: ORDER_HOST
-          value: 'order'
-        - name: CART_HOST
-          value: 'cart'
-        - name: USERS_PORT
-          value: '8083'
-        - name: CATALOG_PORT
-          value: '8082'
-        - name: CART_PORT
-          value: '5000'
-        - name: ORDER_PORT
-          value: '6000'
-        - name: JAEGER_AGENT_HOST
-          value: 'localhost'
-        - name: JAEGER_AGENT_PORT
-          value: '6832'
-        ports:
-        - containerPort: 3000
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-front-end:latest
           name: frontend
+          env:
+            - name: FRONTEND_PORT
+              value: '3000'
+            - name: USERS_HOST
+              value: 'users'
+            - name: CATALOG_HOST
+              value: 'catalog'
+            - name: ORDER_HOST
+              value: 'order'
+            - name: CART_HOST
+              value: 'cart'
+            - name: USERS_PORT
+              value: '8083'
+            - name: CATALOG_PORT
+              value: '8082'
+            - name: CART_PORT
+              value: '5000'
+            - name: ORDER_PORT
+              value: '6000'
+            - name: JAEGER_AGENT_HOST
+              value: 'localhost'
+            - name: JAEGER_AGENT_PORT
+              value: '6832'
+          ports:
+            - containerPort: 3000
+              name: frontend

--- a/kubernetes-manifests/ingress.yaml
+++ b/kubernetes-manifests/ingress.yaml
@@ -8,13 +8,13 @@ metadata:
 spec:
   ingressClassName: "ingress-nginx"
   rules:
-  - host: acme-fitness.sandbox.runwhen.com
-    http:
-      paths:
-      - backend:
-          service:
-            name: frontend
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
+    - host: acme-fitness.sandbox.runwhen.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: frontend
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/kubernetes-manifests/jaeger-all-in-one.yml
+++ b/kubernetes-manifests/jaeger-all-in-one.yml
@@ -15,37 +15,37 @@
 apiVersion: v1
 kind: List
 items:
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: jaeger
-    labels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
-  spec:
-    selector:
-      matchLabels:
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: jaeger
+      labels:
         app: jaeger
         app.kubernetes.io/name: jaeger
         app.kubernetes.io/component: all-in-one
-    replicas: 1
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
+    spec:
+      selector:
+        matchLabels:
           app: jaeger
           app.kubernetes.io/name: jaeger
           app.kubernetes.io/component: all-in-one
-        annotations:
-          prometheus.io/scrape: "true"
-          prometheus.io/port: "16686"
-      spec:
+      replicas: 1
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: jaeger
+            app.kubernetes.io/name: jaeger
+            app.kubernetes.io/component: all-in-one
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "16686"
+        spec:
           containers:
-          -   env:
-              - name: COLLECTOR_ZIPKIN_HTTP_PORT
-                value: "9411"
+            - env:
+                - name: COLLECTOR_ZIPKIN_HTTP_PORT
+                  value: "9411"
               image: jaegertracing/all-in-one
               name: jaeger
               ports:
@@ -66,96 +66,95 @@ items:
                   path: "/"
                   port: 14269
                 initialDelaySeconds: 5
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: jaeger-query
-    labels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: query
-  spec:
-    ports:
-      - name: query-http
-        port: 80
-        protocol: TCP
-        targetPort: 16686
-    selector:
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: jaeger-collector
-    labels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: collector
-  spec:
-    ports:
-    - name: jaeger-collector-tchannel
-      port: 14267
-      protocol: TCP
-      targetPort: 14267
-    - name: jaeger-collector-http
-      port: 14268
-      protocol: TCP
-      targetPort: 14268
-    - name: jaeger-collector-zipkin
-      port: 9411
-      protocol: TCP
-      targetPort: 9411
-    selector:
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
-    type: ClusterIP
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: jaeger-agent
-    labels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: agent
-  spec:
-    ports:
-    - name: agent-zipkin-thrift
-      port: 5775
-      protocol: UDP
-      targetPort: 5775
-    - name: agent-compact
-      port: 6831
-      protocol: UDP
-      targetPort: 6831
-    - name: agent-binary
-      port: 6832
-      protocol: UDP
-      targetPort: 6832
-    - name: agent-configs
-      port: 5778
-      protocol: TCP
-      targetPort: 5778
-    clusterIP: None
-    selector:
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: zipkin
-    labels:
-      app: jaeger
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: zipkin
-  spec:
-    ports:
-    - name: jaeger-collector-zipkin
-      port: 9411
-      protocol: TCP
-      targetPort: 9411
-    clusterIP: None
-    selector:
-      app.kubernetes.io/name: jaeger
-      app.kubernetes.io/component: all-in-one
-
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: jaeger-query
+      labels:
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: query
+    spec:
+      ports:
+        - name: query-http
+          port: 80
+          protocol: TCP
+          targetPort: 16686
+      selector:
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: all-in-one
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: jaeger-collector
+      labels:
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: collector
+    spec:
+      ports:
+        - name: jaeger-collector-tchannel
+          port: 14267
+          protocol: TCP
+          targetPort: 14267
+        - name: jaeger-collector-http
+          port: 14268
+          protocol: TCP
+          targetPort: 14268
+        - name: jaeger-collector-zipkin
+          port: 9411
+          protocol: TCP
+          targetPort: 9411
+      selector:
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: all-in-one
+      type: ClusterIP
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: jaeger-agent
+      labels:
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: agent
+    spec:
+      ports:
+        - name: agent-zipkin-thrift
+          port: 5775
+          protocol: UDP
+          targetPort: 5775
+        - name: agent-compact
+          port: 6831
+          protocol: UDP
+          targetPort: 6831
+        - name: agent-binary
+          port: 6832
+          protocol: UDP
+          targetPort: 6832
+        - name: agent-configs
+          port: 5778
+          protocol: TCP
+          targetPort: 5778
+      clusterIP: None
+      selector:
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: all-in-one
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: zipkin
+      labels:
+        app: jaeger
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: zipkin
+    spec:
+      ports:
+        - name: jaeger-collector-zipkin
+          port: 9411
+          protocol: TCP
+          targetPort: 9411
+      clusterIP: None
+      selector:
+        app.kubernetes.io/name: jaeger
+        app.kubernetes.io/component: all-in-one

--- a/kubernetes-manifests/order-db-total.yaml
+++ b/kubernetes-manifests/order-db-total.yaml
@@ -39,31 +39,31 @@ spec:
         service: order-db
     spec:
       containers:
-      - name: postgres
-        image: postgres:9.5
-        imagePullPolicy: "Always"
-        ports:
-        - containerPort: 5432
-          name: order-postgres
-          protocol: "TCP"
-        env:
-        - name: POSTGRES_USER
-          value: pgbench
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: order-postgres-pass
-              key: password
-        - name: PGBENCH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: order-postgres-pass
-              key: password
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
-        volumeMounts:
-        - mountPath: /var/lib/postgresql/data
-          name: postgredb
+        - name: postgres
+          image: postgres:9.5
+          imagePullPolicy: "Always"
+          ports:
+            - containerPort: 5432
+              name: order-postgres
+              protocol: "TCP"
+          env:
+            - name: POSTGRES_USER
+              value: pgbench
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: order-postgres-pass
+                  key: password
+            - name: PGBENCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: order-postgres-pass
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: postgredb
       volumes:
-      - name: postgredb
-        emptyDir: {}
+        - name: postgredb
+          emptyDir: {}

--- a/kubernetes-manifests/order-total.yaml
+++ b/kubernetes-manifests/order-total.yaml
@@ -36,57 +36,57 @@ spec:
         service: order
     spec:
       volumes:
-      - name: acmefit-order-data
-        emptyDir: {}
+        - name: acmefit-order-data
+          emptyDir: {}
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-order:latest
-        # orderpostgres:latest
-        name: order
-        env:
-        - name: ORDER_DB_HOST
-          value: order-postgres
-        - name: ORDER_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: order-postgres-pass
-              key: password
-        - name: ORDER_DB_PORT
-          value: '5432'
-        - name: AUTH_MODE
-          value: '1'
-        - name: ORDER_DB_USERNAME
-          value: pgbench
-        - name: PGPASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: order-postgres-pass
-              key: password
-        - name: ORDER_AUTH_DB
-          value: postgres
-        - name: ORDER_PORT
-          value: '6000'
-        - name: PAYMENT_PORT
-          value: '9000'
-        - name: PAYMENT_HOST
-          value: 'payment'
-        - name: USER_HOST
-          value: 'users'
-        - name: USER_PORT
-          value: '8083'
-        - name: JAEGER_AGENT_HOST
-          value: 'localhost'
-        - name: JAEGER_AGENT_PORT
-          value: '6831'
-        ports:
-        - containerPort: 6000
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-order:latest
+          # orderpostgres:latest
           name: order
-        volumeMounts:
-        - mountPath: "/data"
-          name: "acmefit-order-data"
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "500m"
+          env:
+            - name: ORDER_DB_HOST
+              value: order-postgres
+            - name: ORDER_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: order-postgres-pass
+                  key: password
+            - name: ORDER_DB_PORT
+              value: '5432'
+            - name: AUTH_MODE
+              value: '1'
+            - name: ORDER_DB_USERNAME
+              value: pgbench
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: order-postgres-pass
+                  key: password
+            - name: ORDER_AUTH_DB
+              value: postgres
+            - name: ORDER_PORT
+              value: '6000'
+            - name: PAYMENT_PORT
+              value: '9000'
+            - name: PAYMENT_HOST
+              value: 'payment'
+            - name: USER_HOST
+              value: 'users'
+            - name: USER_PORT
+              value: '8083'
+            - name: JAEGER_AGENT_HOST
+              value: 'localhost'
+            - name: JAEGER_AGENT_PORT
+              value: '6831'
+          ports:
+            - containerPort: 6000
+              name: order
+          volumeMounts:
+            - mountPath: "/data"
+              name: "acmefit-order-data"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"

--- a/kubernetes-manifests/payment-total.yaml
+++ b/kubernetes-manifests/payment-total.yaml
@@ -36,19 +36,19 @@ spec:
         service: payment
     spec:
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-payment:latest
-        name: payment
-        env:
-        - name: PAYMENT_PORT
-          value: '9000'
-        - name: USERS_HOST
-          value: 'users'
-        - name: USERS_PORT
-          value: '8083'
-        - name: JAEGER_AGENT_HOST
-          value: 'localhost'
-        - name: JAEGER_AGENT_PORT
-          value: '6832'
-        ports:
-        - containerPort: 9000
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-payment:latest
           name: payment
+          env:
+            - name: PAYMENT_PORT
+              value: '9000'
+            - name: USERS_HOST
+              value: 'users'
+            - name: USERS_PORT
+              value: '8083'
+            - name: JAEGER_AGENT_HOST
+              value: 'localhost'
+            - name: JAEGER_AGENT_PORT
+              value: '6832'
+          ports:
+            - containerPort: 9000
+              name: payment

--- a/kubernetes-manifests/point-of-sales-total.yaml
+++ b/kubernetes-manifests/point-of-sales-total.yaml
@@ -38,15 +38,15 @@ spec:
         service: pos
     spec:
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-pos:v0.1.0-beta
-        name: pos
-        env:
-        - name: HTTP_PORT
-          value: '7777'
-        - name: DATASTORE
-          value: 'REMOTE'
-        - name: FRONTEND_HOST
-          value: 'frontend.default.svc.cluster.local'
-        ports:
-        - containerPort: 7777
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-pos:v0.1.0-beta
           name: pos
+          env:
+            - name: HTTP_PORT
+              value: '7777'
+            - name: DATASTORE
+              value: 'REMOTE'
+            - name: FRONTEND_HOST
+              value: 'frontend.default.svc.cluster.local'
+          ports:
+            - containerPort: 7777
+              name: pos

--- a/kubernetes-manifests/users-db-total.yaml
+++ b/kubernetes-manifests/users-db-total.yaml
@@ -26,34 +26,33 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app: acmefit  # has to match .spec.template.metadata.labels
+      app: acmefit # has to match .spec.template.metadata.labels
       service: users-mongo
   replicas: 1
   template:
     metadata:
       labels:
-        app: acmefit  # has to match .spec.selector.matchLabels
+        app: acmefit # has to match .spec.selector.matchLabels
         service: users-mongo
     spec:
       containers:
         - name: users-mongo
           image: mongo:4
-          resources:
-            {}
+          resources: {}
           ports:
             - name: users-mongo
               containerPort: 27017
               protocol: "TCP"
           env:
-          - name: MONGO_INITDB_ROOT_USERNAME
-            value: 'mongoadmin'
-          - name: MONGO_INITDB_DATABASE
-            value: 'acmefit'
-          - name: MONGO_INITDB_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: users-mongo-pass
-                key: password
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: 'mongoadmin'
+            - name: MONGO_INITDB_DATABASE
+              value: 'acmefit'
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: users-mongo-pass
+                  key: password
           volumeMounts:
             - mountPath: /data/db
               name: mongodata
@@ -80,16 +79,16 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 4Gi
   nodeAffinity:
     required:
       nodeSelectorTerms:
         - matchExpressions:
-          - key: app
-            operator: In
-            values:
-              - acmefit
-          - key: service
-            operator: In
-            values:
-              - users-mongo
+            - key: app
+              operator: In
+              values:
+                - acmefit
+            - key: service
+              operator: In
+              values:
+                - users-mongo

--- a/kubernetes-manifests/users-redis-total.yaml
+++ b/kubernetes-manifests/users-redis-total.yaml
@@ -23,13 +23,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: acmefit  # has to match .spec.template.metadata.labels
+      app: acmefit # has to match .spec.template.metadata.labels
       service: users-redis
   replicas: 1
   template:
     metadata:
       labels:
-        app: acmefit  # has to match .spec.selector.matchLabels
+        app: acmefit # has to match .spec.selector.matchLabels
         service: users-redis
     spec:
       containers:
@@ -45,18 +45,18 @@ spec:
               containerPort: 6379
               protocol: "TCP"
           env:
-          - name: REDIS_HOST
-            value: 'users-redis'
-          - name: REDIS_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: users-redis-pass
-                key: password
+            - name: REDIS_HOST
+              value: 'users-redis'
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: users-redis-pass
+                  key: password
           volumeMounts:
             - mountPath: /var/lib/redis
               name: users-redis-data
-#            - mountPath: /etc/redis
-#              name: redis-config
+              #            - mountPath: /etc/redis
+              #              name: redis-config
       volumes:
         - name: users-redis-data
           emptyDir: {}

--- a/kubernetes-manifests/users-total.yaml
+++ b/kubernetes-manifests/users-total.yaml
@@ -36,49 +36,49 @@ spec:
         service: users
     spec:
       volumes:
-      - name: acmefit-users-data
-        emptyDir: {}
+        - name: acmefit-users-data
+          emptyDir: {}
       containers:
-      - image: gcr.io/vmwarecloudadvocacy/acmeshop-user:latest
-        imagePullPolicy: "Always"
-        name: users
-        env:
-        - name: USERS_DB_HOST
-          value: 'users-mongo'
-        - name: USERS_DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: users-mongo-pass
-              key: password
-        - name: USERS_DB_PORT
-          value: '27017'
-        - name: USERS_DB_USERNAME
-          value: 'mongoadmin'
-        - name: USERS_PORT
-          value: '8083'
-        - name: REDIS_HOST
-          value: 'users-redis'
-        - name: REDIS_PORT
-          value: '6379'
-        - name: REDIS_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: users-redis-pass
-              key: password
-        - name: JAEGER_AGENT_HOST
-          value: 'localhost'
-        - name: JAEGER_AGENT_PORT
-          value: '6831'
-        ports:
-        - containerPort: 8083
+        - image: gcr.io/vmwarecloudadvocacy/acmeshop-user:latest
+          imagePullPolicy: "Always"
           name: users
-        volumeMounts:
-        - mountPath: "/data"
-          name: "acmefit-users-data"
-        resources:
-          requests:
-            memory: "64Mi"
-            cpu: "100m"
-          limits:
-            memory: "256Mi"
-            cpu: "500m"
+          env:
+            - name: USERS_DB_HOST
+              value: 'users-mongo'
+            - name: USERS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: users-mongo-pass
+                  key: password
+            - name: USERS_DB_PORT
+              value: '27017'
+            - name: USERS_DB_USERNAME
+              value: 'mongoadmin'
+            - name: USERS_PORT
+              value: '8083'
+            - name: REDIS_HOST
+              value: 'users-redis'
+            - name: REDIS_PORT
+              value: '6379'
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: users-redis-pass
+                  key: password
+            - name: JAEGER_AGENT_HOST
+              value: 'localhost'
+            - name: JAEGER_AGENT_PORT
+              value: '6831'
+          ports:
+            - containerPort: 8083
+              name: users
+          volumeMounts:
+            - mountPath: "/data"
+              name: "acmefit-users-data"
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"


### PR DESCRIPTION
### RunSession Details

A RunSession (started by none) with the following tasks has produced this Pull Request: 

- 

To view the RunSession, click [this link](none/map/none#selectedRunSessions=none)

### Change Details
[Change] Increasing PersistentVolumeClaim `mongodata-users-mongo` attached to `users-mongo-5bd94f8fcc-2jwlz` to `4Gi` in namespace `acme-fitness`.<br>

The following details prompted this change: 
```
{
  "remediation_type": "pvc_increase",
  "object_type": "PersistentVolumeClaim",
  "object_name": "mongodata-users-mongo",
  "pod": "users-mongo-5bd94f8fcc-2jwlz",
  "volume_name": "mongodata",
  "container_name": "users-mongo",
  "mount_path": "/data/db",
  "current_size": "2Gi",
  "usage": "97%",
  "recommended_size": "4Gi",
  "severity": "3"
}
```

---
[RunWhen Workspace](none/map/none)