### PR TITLE
[RunWhen] - GitOps Manifest Updates for PersistentVolumeClaim-mongodata-users-mongo

### DIFF
--- a/kubernetes-manifests/users-db-total.yaml
+++ b/kubernetes-manifests/users-db-total.yaml
@@ -79,7 +79,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 4Gi
+      storage: 5Gi
   nodeAffinity:
     required:
       nodeSelectorTerms:


### PR DESCRIPTION
### RunSession Details

A RunSession (started by shea.stewart@runwhen.com) with the following tasks has produced this Pull Request: 

- Expand Persistent Volume Claims in Namespace `${NAMESPACE}`, Adjust Pod Resources to Match VPA Recommendation in `${NAMESPACE}`

To view the RunSession, click [this link](https://app.beta.runwhen.com/map/b-sandbox#selectedRunSessions=805)

### Change Details
[Change] Increasing PersistentVolumeClaim `mongodata-users-mongo` attached to `users-mongo-5bd94f8fcc-dkcd8` to `5Gi` in namespace `acme-fitness`.<br>

The following details prompted this change: 
```
{
  "remediation_type": "pvc_increase",
  "object_type": "PersistentVolumeClaim",
  "object_name": "mongodata-users-mongo",
  "pod": "users-mongo-5bd94f8fcc-dkcd8",
  "volume_name": "mongodata",
  "container_name": "users-mongo",
  "mount_path": "/data/db",
  "current_size": "4Gi",
  "usage": "89%",
  "recommended_size": "5Gi",
  "severity": "4"
}
```

---
[RunWhen Workspace](https://app.beta.runwhen.com/map/b-sandbox)