### PR TITLE
[RunWhen] - GitOps Manifest Updates for PersistentVolumeClaim-postgredb

### DIFF
--- a/kubernetes-manifests/order-db-total.yaml
+++ b/kubernetes-manifests/order-db-total.yaml
@@ -82,7 +82,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 2Gi
   nodeAffinity:
     required:
       nodeSelectorTerms:


### PR DESCRIPTION
### RunSession Details

A RunSession (started by none) with the following tasks has produced this Pull Request: 

- Expand Persistent Volume Claims in Namespace `${NAMESPACE}`, Increase ResourceQuota for Namespace `${NAMESPACE}`, Remediate Readiness and Liveness Probe GitOps Manifests in Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.beta.runwhen.com/map/b-sandbox?selectedRunSessions=1183)

### Change Details
[Change] Increasing PersistentVolumeClaim `postgredb` attached to `order-postgres-67694dc4b4-tsgxw` to `2Gi` in namespace `acme-fitness`.<br>

The following details prompted this change: 
```
{
  "remediation_type": "pvc_increase",
  "object_type": "PersistentVolumeClaim",
  "object_name": "postgredb",
  "pod": "order-postgres-67694dc4b4-tsgxw",
  "volume_name": "postgredb",
  "container_name": "postgres",
  "mount_path": "/var/lib/postgresql/data",
  "current_size": "1Gi",
  "usage": "100%",
  "recommended_size": "2Gi",
  "severity": "1"
}
```

---
[RunWhen Workspace](https://app.beta.runwhen.com/map/b-sandbox)