### PR TITLE
[RunWhen] - GitOps Manifest Updates for PersistentVolumeClaim-acmefit-catalog-data

### DIFF
--- a/kubernetes-manifests/catalog-total.yaml
+++ b/kubernetes-manifests/catalog-total.yaml
@@ -95,7 +95,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+      storage: 2Gi
   nodeAffinity:
     required:
       nodeSelectorTerms:


### PR DESCRIPTION
### RunSession Details

A RunSession (started by none) with the following tasks has produced this Pull Request: 

- Expand Persistent Volume Claims in Namespace `${NAMESPACE}`

To view the RunSession, click [this link](https://app.beta.runwhen.com/map/b-sandbox?selectedRunSessions=1184)

### Change Details
[Change] Increasing PersistentVolumeClaim `acmefit-catalog-data` attached to `catalog-6cff7b5458-fcf4n` to `2Gi` in namespace `acme-fitness`.<br>

The following details prompted this change: 
```
{
  "remediation_type": "pvc_increase",
  "object_type": "PersistentVolumeClaim",
  "object_name": "acmefit-catalog-data",
  "pod": "catalog-6cff7b5458-fcf4n",
  "volume_name": "acmefit-catalog-data",
  "container_name": "catalog",
  "mount_path": "/data",
  "current_size": "1Gi",
  "usage": "100%",
  "recommended_size": "2Gi",
  "severity": "1"
}
```

---
[RunWhen Workspace](https://app.beta.runwhen.com/map/b-sandbox)